### PR TITLE
Update jruby to 9.3.8.0 because of CVE-2022-25857

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   </modules>
 
   <properties>
-    <jruby.version>9.1.17.0</jruby.version>
+    <jruby.version>9.3.8.0</jruby.version>
   </properties>
 
   <build>

--- a/rubygems-tools/pom.xml
+++ b/rubygems-tools/pom.xml
@@ -127,7 +127,7 @@
         <repository>
           <id>rubygems-proxy</id>
           <name>Rubygems Proxy</name>
-          <url>http://rubygems-proxy.torquebox.org/releases</url>
+          <url>http://mavengems.jruby.org/releases</url>
           <layout>default</layout>
           <releases>
             <enabled>true</enabled>


### PR DESCRIPTION
Upgrade jruby because it transitively download jruby-stdlib which bundles a jar of snakeyaml containing CVE-2022-25857